### PR TITLE
fix(collector): lock the collector before send

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -5,6 +5,8 @@ go 1.21.0
 require (
 	ctx.sh/strata v0.4.1
 	github.com/go-logr/logr v1.2.4
+	github.com/prometheus/client_model v0.4.0
+	github.com/prometheus/common v0.44.0
 	k8s.io/api v0.28.0
 	k8s.io/apimachinery v0.28.0
 	k8s.io/client-go v0.28.0
@@ -41,8 +43,6 @@ require (
 	github.com/pkg/errors v0.9.1 // indirect
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/prometheus/client_golang v1.16.0 // indirect
-	github.com/prometheus/client_model v0.4.0 // indirect
-	github.com/prometheus/common v0.44.0 // indirect
 	github.com/prometheus/procfs v0.10.1 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/stretchr/testify v1.8.4 // indirect

--- a/pkg/collector/collector.go
+++ b/pkg/collector/collector.go
@@ -6,4 +6,6 @@ type Collector interface {
 	SendChan() chan<- resource.Resource
 	Start()
 	Stop()
+	Lock()
+	Unlock()
 }

--- a/pkg/collector/pool.go
+++ b/pkg/collector/pool.go
@@ -27,6 +27,7 @@ type Pool struct {
 	discard bool
 
 	stopOnce sync.Once
+	sync.Mutex
 }
 
 func NewPool(namespace, name string, opts *PoolOpts) *Pool {
@@ -67,3 +68,5 @@ func (p *Pool) SendChan() chan<- resource.Resource {
 func (p *Pool) NamespacedName() types.NamespacedName {
 	return p.namespacedName
 }
+
+var _ Collector = &Pool{}


### PR DESCRIPTION
Instead of passing around send channels, get the collectors one at a time and lock them.  More work needs to be done around making the send functions async and allowing for timeouts which would effectively drop any remaining metrics to be sent.