### PR TITLE
feat(discovery): Use date for status output

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -35,10 +35,10 @@ In general we'll try to stay away from specific vendor implementations, though I
 
 
 Tommorrow:
-* SendChan to registry. Maybe break up the registry settings from the "manager" settings.  Manager would take the startup/shutdown, then everything has the registry.
-* Last modified to time.Since from the last run (for discovery).
-* Add Age to collector and discovery.
-* Flags.
-* Lay out encoders?
-* Validation either inline or in the validation hooks.
-* Start looking at testing using kubebuilder and controller-runtime as an example.
+* [] SendChan to registry. Maybe break up the registry settings from the "manager" settings.  Manager would take the startup/shutdown, then everything has the registry.
+* [x] Last modified to time.Since from the last run (for discovery).
+* [] Add Age to collector and discovery.
+* [] Flags.
+* [] Lay out encoders?
+* [] Validation either inline or in the validation hooks.
+* [] Start looking at testing using kubebuilder and controller-runtime as an example.

--- a/config/crd/strata.ctx.sh_discoveries.yaml
+++ b/config/crd/strata.ctx.sh_discoveries.yaml
@@ -36,8 +36,8 @@ spec:
       priority: 1
       type: integer
     - jsonPath: .status.lastDiscovered
-      name: Last Discovered
-      type: string
+      name: Last
+      type: date
     name: v1beta1
     schema:
       openAPIV3Schema:

--- a/pkg/apis/strata.ctx.sh/v1beta1/types.go
+++ b/pkg/apis/strata.ctx.sh/v1beta1/types.go
@@ -74,7 +74,7 @@ type DiscoveryStatus struct {
 // +kubebuilder:printcolumn:name="Total Collectors",type="integer",JSONPath=".status.totalCollectors",priority=1
 // +kubebuilder:printcolumn:name="Discovered",type="integer",JSONPath=".status.discoveredResourcesCount",priority=1
 // +kubebuilder:printcolumn:name="In Flight",type="integer",JSONPath=".status.inFlightResources",priority=1
-// +kubebuilder:printcolumn:name="Last Discovered",type="string",JSONPath=".status.lastDiscovered"
+// +kubebuilder:printcolumn:name="Last",type="date",JSONPath=".status.lastDiscovered"
 
 // Discovery represents a discovery service that will collect pods, services, and
 // endpoints from a k8s cluster.

--- a/pkg/service/prometheus_scraper.go
+++ b/pkg/service/prometheus_scraper.go
@@ -26,6 +26,8 @@ func NewPrometheusScraper(client http.Client, url string) *PrometheusScraper {
 }
 
 func (p *PrometheusScraper) Get(tags map[string]string) ([]*Metric, error) {
+	// TODO: Add timeout, scheme, and other options - this is just a quick
+	// implementation to get things working.
 	req, _ := http.NewRequest("GET", p.Url, nil)
 	resp, err := p.Client.Do(req)
 	if err != nil {


### PR DESCRIPTION
Use the date format for status output for the last run.  This gives us the normal (and more useful) "time since last" output.