### PR TITLE
feat(registry): registry manages send channels 

### DIFF
--- a/TODO.md
+++ b/TODO.md
@@ -35,10 +35,11 @@ In general we'll try to stay away from specific vendor implementations, though I
 
 
 Tommorrow:
-* [] SendChan to registry. Maybe break up the registry settings from the "manager" settings.  Manager would take the startup/shutdown, then everything has the registry.
+* [x] SendChan to registry. Maybe break up the registry settings from the "manager" settings.  Manager would take the startup/shutdown, then everything has the registry.
 * [x] Last modified to time.Since from the last run (for discovery).
 * [x] Add Age to collector and discovery.
 * [] Flags.
 * [] Lay out encoders?
 * [] Validation either inline or in the validation hooks.
 * [] Start looking at testing using kubebuilder and controller-runtime as an example.
+* [] Status updates outside of the normal interval runs.

--- a/pkg/controller/collector/controller.go
+++ b/pkg/controller/collector/controller.go
@@ -20,7 +20,7 @@ type Controller struct {
 	Client   client.Client
 	Log      logr.Logger
 	Mgr      ctrl.Manager
-	Registry *service.Registry
+	Services *service.Manager
 }
 
 // SetupWithManager creates a new controller for the supplied manager which
@@ -43,7 +43,7 @@ func (r *Controller) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		client:   r.Mgr.GetClient(),
 		log:      r.Log.WithValues("name", request.Name, "namespace", request.Namespace),
 		recorder: r.Mgr.GetEventRecorderFor("StrataCollector"),
-		registry: r.Registry,
+		services: r.Services,
 	}
 	return handler.reconcile(ctx, request)
 }

--- a/pkg/controller/collector/handler.go
+++ b/pkg/controller/collector/handler.go
@@ -15,7 +15,7 @@ type Handler struct {
 	log      logr.Logger
 	recorder record.EventRecorder
 	observed Observed
-	registry *service.Registry
+	services *service.Manager
 }
 
 func (h *Handler) reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
@@ -37,7 +37,7 @@ func (h *Handler) reconcile(ctx context.Context, request ctrl.Request) (ctrl.Res
 		log:      h.log,
 		recorder: h.recorder,
 		observed: h.observed,
-		registry: h.registry,
+		services: h.services,
 	}
 
 	result, err := reconciler.reconcile(ctx, request)

--- a/pkg/controller/collector/reconciler.go
+++ b/pkg/controller/collector/reconciler.go
@@ -17,7 +17,7 @@ type Reconciler struct {
 	log      logr.Logger
 	observed Observed
 	recorder record.EventRecorder
-	registry *service.Registry
+	services *service.Manager
 }
 
 var requeueResult reconcile.Result = ctrl.Result{
@@ -27,7 +27,7 @@ var requeueResult reconcile.Result = ctrl.Result{
 
 func (r *Reconciler) reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
 	if r.observed.collector == nil {
-		if err := r.registry.DeleteCollectionPool(request.NamespacedName); err != nil {
+		if err := r.services.DeleteCollectionPool(request.NamespacedName); err != nil {
 			r.log.Error(err, "unable to delete collection pool")
 			return ctrl.Result{}, err
 		}
@@ -35,7 +35,7 @@ func (r *Reconciler) reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return ctrl.Result{}, nil
 	}
 
-	if err := r.registry.AddCollectionPool(ctx, request.NamespacedName, *r.observed.collector); err != nil {
+	if err := r.services.AddCollectionPool(ctx, request.NamespacedName, *r.observed.collector); err != nil {
 		return requeueResult, err
 	}
 

--- a/pkg/controller/controller.go
+++ b/pkg/controller/controller.go
@@ -18,7 +18,7 @@ type Controller struct {
 	mgr      ctrl.Manager
 	logger   logr.Logger
 	metrics  *strata.Metrics
-	registry *service.Registry
+	services *service.Manager
 }
 
 func New(mgr ctrl.Manager, opts *ControllerOpts) *Controller {
@@ -26,9 +26,7 @@ func New(mgr ctrl.Manager, opts *ControllerOpts) *Controller {
 		mgr:     mgr,
 		logger:  opts.Logger,
 		metrics: opts.Metrics,
-		registry: service.NewRegistry(mgr, &service.RegistryOpts{
-			Cache:   mgr.GetCache(),
-			Client:  mgr.GetClient(),
+		services: service.NewManager(mgr, &service.ManagerOpts{
 			Logger:  opts.Logger,
 			Metrics: opts.Metrics,
 		}),
@@ -41,7 +39,7 @@ func (c *Controller) Setup() error {
 		Client:   c.mgr.GetClient(),
 		Cache:    c.mgr.GetCache(),
 		Log:      c.mgr.GetLogger().WithValues("controller", "collector"),
-		Registry: c.registry,
+		Services: c.services,
 	}
 
 	err := collectorController.SetupWithManager(c.mgr)
@@ -53,7 +51,7 @@ func (c *Controller) Setup() error {
 	discoveryController := &discovery.Controller{
 		Client:   c.mgr.GetClient(),
 		Log:      c.mgr.GetLogger().WithValues("controller", "discovery"),
-		Registry: c.registry,
+		Services: c.services,
 	}
 
 	err = discoveryController.SetupWithManager(c.mgr)

--- a/pkg/controller/discovery/controller.go
+++ b/pkg/controller/discovery/controller.go
@@ -17,7 +17,7 @@ type Controller struct {
 	Client   client.Client
 	Log      logr.Logger
 	Mgr      ctrl.Manager
-	Registry *service.Registry
+	Services *service.Manager
 }
 
 // SetupWithManager creates a new controller for the supplied manager which
@@ -46,7 +46,7 @@ func (r *Controller) Reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		client:   r.Mgr.GetClient(),
 		log:      r.Log.WithValues("name", request.Name, "namespace", request.Namespace),
 		recorder: r.Mgr.GetEventRecorderFor("StrataDiscovery"),
-		registry: r.Registry,
+		services: r.Services,
 	}
 	return handler.reconcile(ctx, request)
 }

--- a/pkg/controller/discovery/handler.go
+++ b/pkg/controller/discovery/handler.go
@@ -15,7 +15,7 @@ type Handler struct {
 	log      logr.Logger
 	recorder record.EventRecorder
 	observed Observed
-	registry *service.Registry
+	services *service.Manager
 }
 
 func (h *Handler) reconcile(ctx context.Context, request ctrl.Request) (ctrl.Result, error) {
@@ -37,7 +37,7 @@ func (h *Handler) reconcile(ctx context.Context, request ctrl.Request) (ctrl.Res
 		log:      h.log,
 		recorder: h.recorder,
 		observed: h.observed,
-		registry: h.registry,
+		services: h.services,
 	}
 
 	result, err := reconciler.reconcile(ctx, request)

--- a/pkg/controller/discovery/reconciler.go
+++ b/pkg/controller/discovery/reconciler.go
@@ -17,7 +17,7 @@ type Reconciler struct {
 	log      logr.Logger
 	observed Observed
 	recorder record.EventRecorder
-	registry *service.Registry
+	services *service.Manager
 }
 
 var requeueResult reconcile.Result = ctrl.Result{
@@ -30,7 +30,7 @@ func (r *Reconciler) reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 
 	if r.observed.discovery == nil {
 		r.log.V(8).Info("discovery service not found, deleting registry entry")
-		err := r.registry.DeleteDiscoveryService(request.NamespacedName)
+		err := r.services.DeleteDiscoveryService(request.NamespacedName)
 		if err != nil {
 			r.log.Error(err, "unable to delete discovery service")
 			// TODO: Need to think through the conditions here and whether we should requeue the request.
@@ -39,7 +39,7 @@ func (r *Reconciler) reconcile(ctx context.Context, request ctrl.Request) (ctrl.
 		return ctrl.Result{}, nil
 	}
 
-	err := r.registry.AddDiscoveryService(ctx, r.observed.discovery.DeepCopy())
+	err := r.services.AddDiscoveryService(ctx, r.observed.discovery.DeepCopy())
 	if err != nil {
 		r.log.Error(err, "unable to add discovery service")
 		return requeueResult, err

--- a/pkg/service/collection_pool.go
+++ b/pkg/service/collection_pool.go
@@ -12,20 +12,21 @@ import (
 )
 
 type CollectionPoolOpts struct {
-	Discard bool
-	Logger  logr.Logger
-	Metrics *strata.Metrics
+	Discard  bool
+	Logger   logr.Logger
+	Metrics  *strata.Metrics
+	Registry *Registry
 }
 
 type CollectionPool struct {
 	namespacedName types.NamespacedName
 	numWorkers     int64
 	workers        []*CollectionWorker
+	registry       *Registry
 	recvChan       chan resource.Resource
 	logger         logr.Logger
 	metrics        *strata.Metrics
 	output         sink.Sink
-	discard        bool
 
 	stopOnce sync.Once
 	sync.Mutex
@@ -37,7 +38,7 @@ func NewCollectionPool(obj v1beta1.Collector, opts *CollectionPoolOpts) *Collect
 			Namespace: obj.GetNamespace(),
 			Name:      obj.GetName(),
 		},
-		discard: opts.Discard,
+		registry: opts.Registry,
 		// TODO: hmmm, how to handle this?
 		output:     FromObject(*obj.Spec.Output),
 		numWorkers: *obj.Spec.Workers,

--- a/pkg/service/collection_worker.go
+++ b/pkg/service/collection_worker.go
@@ -75,6 +75,7 @@ func (w *CollectionWorker) collect(r resource.Resource) ([]*Metric, error) {
 }
 
 func (w *CollectionWorker) send(metrics []*Metric) error {
+
 	for _, m := range metrics {
 		err := w.output.Send(m.Bytes())
 		if err != nil {

--- a/pkg/service/manager.go
+++ b/pkg/service/manager.go
@@ -1,0 +1,74 @@
+package service
+
+import (
+	"context"
+
+	"ctx.sh/strata"
+	"ctx.sh/strata-collector/pkg/apis/strata.ctx.sh/v1beta1"
+	"github.com/go-logr/logr"
+	"k8s.io/apimachinery/pkg/types"
+	ctrl "sigs.k8s.io/controller-runtime"
+	"sigs.k8s.io/controller-runtime/pkg/cache"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+type ManagerOpts struct {
+	Logger  logr.Logger
+	Metrics *strata.Metrics
+}
+
+type Manager struct {
+	registry *Registry
+
+	logger  logr.Logger
+	metrics *strata.Metrics
+
+	cache  cache.Cache
+	client client.Client
+}
+
+func NewManager(mgr ctrl.Manager, opts *ManagerOpts) *Manager {
+	return &Manager{
+		registry: NewRegistry(),
+		logger:   opts.Logger,
+		metrics:  opts.Metrics,
+		cache:    mgr.GetCache(),
+		client:   mgr.GetClient(),
+	}
+}
+
+// TODO: don't need key
+func (m *Manager) AddDiscoveryService(ctx context.Context, obj *v1beta1.Discovery) error {
+	key := types.NamespacedName{
+		Namespace: obj.Namespace,
+		Name:      obj.Name,
+	}
+
+	svc := NewDiscovery(obj, &DiscoveryOpts{
+		Cache:    m.cache,
+		Client:   m.client,
+		Logger:   m.logger.WithValues("discovery", key),
+		Registry: m.registry,
+	})
+
+	m.logger.Info("adding discovery service", "discovery", key)
+	return m.registry.AddDiscoveryService(key, svc)
+}
+
+func (m *Manager) DeleteDiscoveryService(key types.NamespacedName) error {
+	return m.registry.DeleteDiscoveryService(key)
+}
+
+func (m *Manager) AddCollectionPool(ctx context.Context, key types.NamespacedName, obj v1beta1.Collector) error {
+	collector := NewCollectionPool(obj, &CollectionPoolOpts{
+		Logger:   m.logger.WithValues("collector", key),
+		Metrics:  m.metrics,
+		Registry: m.registry,
+	})
+
+	return m.registry.AddCollectionPool(key, collector)
+}
+
+func (m *Manager) DeleteCollectionPool(key types.NamespacedName) error {
+	return m.registry.DeleteCollectionPool(key)
+}

--- a/pkg/service/manager.go
+++ b/pkg/service/manager.go
@@ -51,7 +51,6 @@ func (m *Manager) AddDiscoveryService(ctx context.Context, obj *v1beta1.Discover
 		Registry: m.registry,
 	})
 
-	m.logger.Info("adding discovery service", "discovery", key)
 	return m.registry.AddDiscoveryService(key, svc)
 }
 

--- a/pkg/service/types.go
+++ b/pkg/service/types.go
@@ -3,8 +3,7 @@ package service
 import "ctx.sh/strata-collector/pkg/resource"
 
 type Collector interface {
-	SendChan() chan<- resource.Resource
-	Start()
+	Start(<-chan resource.Resource)
 	Stop()
 	Lock()
 	Unlock()


### PR DESCRIPTION
To ensure that there are no dropped metrics in the system when we
update/delete objects, the registry will manage the channel lifecycle
and associate both the collector and discovery services to them.  The
registry has been broken up into 2 parts.  The manager which is exposed
to the controller, giving the entrypoints/abstractions to add and delete
and the registry operations.  This keeps us from any circular
dependencies as we expose the registry to both the discovery and
collextion services.  The registry will create a send channel on the
addition of any new collector and remove that channel when the collector
has been removed by the controller.  It remains intact during updates
where the original underlying object is being rotated out.